### PR TITLE
Reject trailing bytes

### DIFF
--- a/flatbencode.py
+++ b/flatbencode.py
@@ -135,7 +135,7 @@ def encode(obj):
 
         if isinstance(obj, dict):
             if not all(isinstance(k, (bytes, str)) for k in obj.keys()):
-                raise ValueError("Dictionnary keys must be strings")
+                raise ValueError("Dictionary keys must be strings")
             yield DICT_START
             for k, v in obj.items():
                 yield from generator(k)

--- a/flatbencode.py
+++ b/flatbencode.py
@@ -121,6 +121,8 @@ def decode(s):
             elem = _read_string(c, buf)
 
         if not stack:
+            if buf.read(ONE_CHAR):  # End of string?
+                raise DecodingError
             return elem
         else:
             stack.append(elem)

--- a/flatbencode.py
+++ b/flatbencode.py
@@ -130,9 +130,6 @@ def decode(s):
 
 def encode(obj):
     def generator(obj):
-        if isinstance(obj, str):
-            obj = obj.encode('utf-8')  # XXX: Because utf-8 is universal?
-
         if isinstance(obj, dict):
             if not all(isinstance(k, (bytes, str)) for k in obj.keys()):
                 raise ValueError("Dictionary keys must be strings")

--- a/test_flatbencode.py
+++ b/test_flatbencode.py
@@ -74,6 +74,7 @@ def test_order_is_preserved():
     b'i03e',
     b'i-0e',
     b'dlelee',
+    b'i5etrailing',
 ])
 def test_invalid_values(data):
     with pytest.raises(DecodingError):


### PR DESCRIPTION
`i5e` correctly decodes to 5.
But `i5eLOL` should not decode to 5.
