### PR TITLE
Include LICENSE file in release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
+include LICENSE
 recursive-include *.py


### PR DESCRIPTION
Currently the LICENSE file isn't included in release tarballs, this is an inconvenience for linux distribution packaging.